### PR TITLE
feat(power): cache the previous power reading (#7)

### DIFF
--- a/src/kasa.rs
+++ b/src/kasa.rs
@@ -69,7 +69,7 @@ struct KasaRealtimeResponse {
     pub total_wh: Option<u64>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq)]
 pub(crate) struct KasaPowerDetails {
     pub alias: String,
     pub device_id: String,


### PR DESCRIPTION
The kasa plug doesnt update the power every time we query it. As such, lets avoid sending a lot of duplicate power readings upstream when we know they arent additive.